### PR TITLE
generate_config.sh: significantly shrink configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ See Customisation below on how to pass a custom user/password into the deploymen
 ## Test the set-up locally
 
 You can test locally in a qemu VM.
-Uncomment the local test settings at the bottom of [`jitsi-config.env`](jitsi-config.env),
-disable `DEPLOY_SET_PUBLIC_IP` in [jitsi-install.env](jitsi-install.env),
-and re-generate the configuration.
+1. Uncomment the local test settings at the bottom of [`jitsi-config.env`](jitsi-config.env), then
+2. disable `DEPLOY_SET_PUBLIC_IP` in [jitsi-install.env](jitsi-install.env), and
+3. re-generate the configuration by running `./generate_config.sh`
 
 Fetch the latest `flatcar_production_qemu_uefi_efi_code.fd`,
  `flatcar_production_qemu_uefi_efi_vars.fd`,

--- a/config.yaml.tmpl
+++ b/config.yaml.tmpl
@@ -49,13 +49,6 @@ storage:
       contents:
         local: jitsi-install.env
 
-    - path: /opt/jitsi/installer/config.yaml
-      mode: 0644
-      user:
-        name: jitsi
-      contents:
-        local: config.yaml
-
     - path: /etc/systemd/system/jitsi.service
       mode: 0644
       user:
@@ -84,6 +77,13 @@ storage:
       contents:
         local: jitsi-config.env
 
+    - path: /opt/jitsi/installer/branding-docker-compose.yml.patch
+      mode: 0644
+      user:
+        name: jitsi
+      contents:
+        local: @BRANDING_PATCH_FILE@
+
     - path: /opt/jitsi/installer/flatcar_banner.png
       mode: 0644
       user:
@@ -96,43 +96,43 @@ storage:
       user:
         name: jitsi
       contents:
-        local: resources/flatcar_logo-vertical-stacked-black.svg
+        source: https://raw.githubusercontent.com/flatcar/jitsi-server/main/resources/flatcar_logo-vertical-stacked-black.svg
 
     - path: /opt/jitsi/installer/flatcar_logo-vertical-stacked.svg
       mode: 0644
       user:
         name: jitsi
       contents:
-        local: resources/flatcar_logo-vertical-stacked.svg
+        source: https://raw.githubusercontent.com/flatcar/jitsi-server/main/resources/flatcar_logo-vertical-stacked.svg
 
-    # These are downloaded by generate_config.sh for the jitsi release specified
+    # These are customised by generate_config.sh for the jitsi release specified
     - path: /opt/jitsi/installer/env.example
       mode: 0644
       user:
         name: jitsi
       contents:
-        local: env.example
+        source: @JITSI_BASE_URL@/env.example
 
     - path: /opt/jitsi/installer/docker-compose.yml
       mode: 0644
       user:
         name: jitsi
       contents:
-        local: docker-compose.yml
+        source: @JITSI_BASE_URL@/docker-compose.yml
 
     - path: /opt/jitsi/installer/jibri.yml
       mode: 0644
       user:
         name: jitsi
       contents:
-        local: jibri.yml
+        source: @JITSI_BASE_URL@/jibri.yml
 
     - path: /opt/jitsi/installer/gen-passwords.sh
       mode: 0755
       user:
         name: jitsi
       contents:
-        local: gen-passwords.sh
+        source: @JITSI_BASE_URL@/gen-passwords.sh
 
 
 passwd:

--- a/jitsi-install.sh
+++ b/jitsi-install.sh
@@ -94,9 +94,12 @@ cp "${INSTALLER_DIR}/env.example" \
    "${INSTALLER_DIR}/docker-compose.yml" \
    "${INSTALLER_DIR}/jibri.yml" \
    "${INSTALLER_DIR}/gen-passwords.sh" \
+   "${INSTALLER_DIR}/branding-docker-compose.yml.patch" \
    "${DEST_DIR}"/
 
 cd "${DEST_DIR}"
+
+git apply branding-docker-compose.yml.patch
 
 mv env.example .env
 ./gen-passwords.sh

--- a/resources/empty-branding-docker-compose.yml.patch
+++ b/resources/empty-branding-docker-compose.yml.patch
@@ -1,0 +1,4 @@
+diff --git docker-compose.yml docker-compose.yml
+index 22261bb..ee6f1e5 100644
+--- a/docker-compose.yml
++++ b/docker-compose.yml


### PR DESCRIPTION
This change uses external sources for most provisioning resources, most notably the Jitsi docker compose YAML files.
Applying branding customisation is moved to the installer script, though it is tested by generate_config.sh.

## Testing done

Tested in a local qemu VM in accordance with local test instructions in the repository's Readme. Improved documentation while I was at it.