### PR TITLE
jitsi-config.env: enable moderation features, break-out rooms

### DIFF
--- a/jitsi-config.env
+++ b/jitsi-config.env
@@ -20,7 +20,9 @@ LETSENCRYPT_DOMAIN=${JITSI_SERVER_FQDN}
 LETSENCRYPT_EMAIL="infra@flatcar-linux.org"
 
 # Jitsi features / settings
-TOOLBAR_BUTTONS="select-background,microphone,camera,closedcaptions,desktop,fullscreen,fodeviceselection,hangup,profile,chat,recording,livestreaming,settings,raisehand,videoquality,stats,shortcuts,tileview,security"
+# See 'toolbarButtons' in https://github.com/jitsi/jitsi-meet/blob/master/config.js for the full list.
+TOOLBAR_BUTTONS="camera,chat,closedcaptions,desktop,embedmeeting,fodeviceselection,fullscreen,hangup,help,highlight,livestreaming,microphone,noisesuppression,participants-pane,profile,raisehand,recording,security,select-background,settings,shareaudio,shortcuts,stats,tileview,toggle-camera,videoquality"
+
 ENABLE_LIVESTREAMING=1
 ENABLE_RECORDING=1
 JIBRI_RECORDING_RESOLUTION="1920x1080"
@@ -30,6 +32,13 @@ ENABLE_GUESTS=1
 AUTH_TYPE=internal
 ENABLE_LOBBY=1
 
+ENABLE_AV_MODERATION=1
+ENABLE_NOISY_MIC_DETECTION=1
+ENABLE_NO_AUDIO_DETECTION=1
+ENABLE_BREAKOUT_ROOMS=1
+
+ENABLE_LOCAL_RECORDING_NOTIFY_ALL_PARTICIPANT=1
+ENABLE_LOCAL_RECORDING_SELF_START=1
 
 # This is handy for local testing, e.g. in a qemu VM
 #HTTP_PORT=4080


### PR DESCRIPTION
This change enables more Jitsi features that became available upstream. Among other things, participants list, breakout rooms, and AV moderation are now enabled.

Tested interactively on an Akamai deployment.